### PR TITLE
fix: Ensure EMSS pipeline is properly torn down on unexpected connection terminations

### DIFF
--- a/wasm/main.cpp
+++ b/wasm/main.cpp
@@ -83,6 +83,9 @@ void MoonlightInstance::OnConnectionStopped(uint32_t error) {
   // Unlock the mouse
   UnlockMouse();
 
+  // Spawn teardown thread to cleanup EMSS pipeline
+  pthread_create(&m_StopThread, NULL, MoonlightInstance::StopThreadFunc, NULL);
+
   // Notify the JS code that the stream has ended
   PostToJs(std::string(MSG_STREAM_TERMINATED + std::to_string((int)error)));
 }
@@ -92,11 +95,6 @@ void MoonlightInstance::StopConnection() {
   g_Instance->m_EmssStateChanged.notify_all();
   g_Instance->m_EmssAudioStateChanged.notify_all();
   g_Instance->m_EmssVideoStateChanged.notify_all();
-
-  // Stopping needs to happen in a separate thread to avoid a potential deadlock
-  // caused by us getting a callback to the main thread while inside
-  // LiStopConnection.
-  pthread_create(&m_StopThread, NULL, MoonlightInstance::StopThreadFunc, NULL);
 
   // We'll need to call the listener ourselves since our connection terminated
   // callback won't be invoked for a manually requested termination.


### PR DESCRIPTION
## Description

This PR fixes an issue where the EMSS audio/video pipeline was not being properly cleaned up if the connection was terminated unexpectedly with "Connection terminated" message (e.g., Sunshine disconnect, Wi-Fi router restart). 

Previously, the teardown thread (`m_StopThread`) was only spawned inside `StopConnection()`. This meant that if the stream ended gracefully or ungracefully outside of a manual stop request (RED button), the EMSS pipeline would never be torn down, potentially leading to memory leaks, frozen states, or crashes when attempting to start a new session.

By moving the EMSS teardown thread creation from `StopConnection()` to `OnConnectionStopped()`, we ensure that the EMSS pipeline cleanup is always triggered regardless of how the connection ends.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
