### PR TITLE
fix: Reset last frame number on stream start to prevent stats underflow

### DIFF
--- a/wasm/wasmplayer.cpp
+++ b/wasm/wasmplayer.cpp
@@ -320,6 +320,9 @@ int MoonlightInstance::VidDecSetup(int videoFormat, int width, int height, int r
   // Reset global video statistics for new decoding session
   memset(&m_GlobalVideoStats, 0, sizeof(m_GlobalVideoStats));
 
+  // Reset last frame number to prevent massive integer underflow on subsequent streams
+  m_LastFrameNumber = 0;
+
   // Ensure that StartupVidDecSetup is called every time when VidDecSetup is invoked to reinitialize the media pipeline
   int initVidDec = StartupVidDecSetup(videoFormat, width, height, redrawRate, context, drFlags);
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the "Frames dropped by your network connection" and "Video stream FPS" statistics would completely break (often locking permanently) when starting a new stream session without restarting the app. Stats now correctly calculate dropped frames across multiple consecutive sessions without requiring an app restart.

The issue occurred because the static variable `m_LastFrameNumber` retained its state from the previous stream. When a new stream started, `decodeUnit->frameNumber` would reset to `0`, but `m_LastFrameNumber` might still be at `50,000`. This caused the difference calculation `decodeUnit->frameNumber - (m_LastFrameNumber + 1)` to evaluate to a massive negative number, resulting in a severe integer underflow that corrupted both `networkDroppedFrames` and `totalFrames`.

Please include a summary of the changes made in this pull request:
- Reset `m_LastFrameNumber = 0` inside the `VidDecSetup` method, guaranteeing a clean slate for the frame sequence tracker on every new connection.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
