### PR TITLE
fix: Synchronize stale base URLs and add LocalIP fallback for polling

### DIFF
--- a/wasm/static/js/mdns-browser/main.js
+++ b/wasm/static/js/mdns-browser/main.js
@@ -24,13 +24,6 @@ function findNvService(ipString) {
   // .local hostnames, and the HTTP subnet scanner only produces IPv4 addresses.
   var ip = ipString.replace('ipv4:', '');
 
-  // Skip hosts we have already registered by this exact IP address
-  for (var hostUID in hosts) {
-    if (hosts[hostUID].address === ip) {
-      return;
-    }
-  }
-
   // Create a new NvHTTP object for the discovered host
   var discoveredHost = new NvHTTP(ip, myUniqueid);
   discoveredHost.httpPort = 47989;
@@ -46,11 +39,12 @@ function findNvService(ipString) {
     if (hosts[returnedDiscoveredHost.serverUid] != null) {
       // Host already known — update its stored IP if it has changed
       var existingAddress = hosts[returnedDiscoveredHost.serverUid].address;
-      // Check if the existing address is different from the newly discovered address
-      if (existingAddress !== returnedDiscoveredHost.address) {
+      // Also check if the base URL is out of sync or stale compared to the discovered host
+      var existingBaseUrl = hosts[returnedDiscoveredHost.serverUid]._baseUrlHttps;
+      if (existingAddress !== returnedDiscoveredHost.address || existingBaseUrl !== returnedDiscoveredHost._baseUrlHttps) {
         var isIpv4 = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$/.test(existingAddress);
         // Do not overwrite IPv6 or DNS addresses if they are currently online
-        if (!isIpv4 && hosts[returnedDiscoveredHost.serverUid].online) {
+        if (!isIpv4 && hosts[returnedDiscoveredHost.serverUid].online && existingBaseUrl === returnedDiscoveredHost._baseUrlHttps) {
           console.log('%c[main.js, findNvService]', 'color: gray;', 'Keeping existing non-IPv4 address since it is online:', existingAddress);
         } else {
           // Update the stored address to the newly discovered IPv4 address

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -315,6 +315,7 @@ NvHTTP.prototype = {
     // Only append '.local' if the hostname doesn't already end with it
     var localSuffix = this.hostname.endsWith('.local') ? this.hostname : this.hostname + '.local';
     addCandidate(localSuffix);
+    addCandidate(this.localAddress);
     addCandidate(this.externalIP);
     addCandidate(this.userEnteredAddress);
 


### PR DESCRIPTION
## Description

This PR addresses an edge case where a host's `_baseUrlHttps` in the database could become permanently out of sync with its `address`, causing background polling to fail with `net::ERR_ADDRESS_UNREACHABLE` or `net::ERR_CONNECTION_REFUSED` immediately upon application startup. It also improves connection reliability by utilizing the `<LocalIP>` returned by Sunshine.

### Changes Made
1. **Removed Early Discovery Exit (`wasm/static/js/mdns-browser/main.js`)**: 
   Previously, if the subnet scanner discovered a host, `findNvService()` would bail out early if the discovered IP matched the host's `address` property in the database, even if the underlying `_baseUrlHttps` endpoints were stale. It now verifies that both the `address` and `_baseUrlHttps` match, forcefully resynchronizing the database if the base URL is broken.
   
2. **Added LocalIP Fallback (`wasm/static/js/utils.js`)**: 
   Sunshine explicitly reports its local IP address in the `/serverinfo` payload, which Moonlight parses and stores as `this.localAddress`. However, this was completely missing from the fallback candidates list in `selectServerAddress()`. It has now been added as a candidate, ensuring Moonlight attempts to connect to the explicit IP reported by the server before falling back to other addresses or giving up.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
