### PR TITLE
fix: Integer underflow in decoding time calculations in performance stats overlay

### DIFF
--- a/wasm/wasmplayer.cpp
+++ b/wasm/wasmplayer.cpp
@@ -506,8 +506,8 @@ int MoonlightInstance::VidDecSubmitDecodeUnit(PDECODE_UNIT decodeUnit) {
   };
 
   // Track total time spent reassembling and decoding this frame
-  m_ActiveWndVideoStats.totalReassemblyTime += decodeUnit->enqueueTimeMs - decodeUnit->receiveTimeMs;
-  m_ActiveWndVideoStats.totalDecodeTime += LiGetMillis() - decodeUnit->enqueueTimeMs;
+  m_ActiveWndVideoStats.totalReassemblyTime += (uint32_t)MAX(0, (int32_t)(decodeUnit->enqueueTimeMs - decodeUnit->receiveTimeMs));
+  m_ActiveWndVideoStats.totalDecodeTime += (uint32_t)MAX(0, (int32_t)(LiGetMillis() - decodeUnit->enqueueTimeMs));
   m_ActiveWndVideoStats.decodedFrames++;
 
   // Calculate time before rendering


### PR DESCRIPTION
## What does this fix?
Resolves an issue where the "Average Decoding Time" in the performance overlay would occasionally display absurdly large numbers (e.g., `70409296.00 ms`).

![Image](https://github.com/user-attachments/assets/62d418d6-e0bd-4825-bd61-2647a96799c9)

## Why was this happening?
The WebAssembly player runs its network processing and video decoding on two separate Web Workers. In the Tizen browser, Web Workers do not share a perfectly synchronized clock—each worker's internal timer starts from zero at the exact millisecond it is created.

Because the Network Worker is spawned a few milliseconds before the Decoder Worker, its internal clock is slightly ahead. When we subtracted the frame's network enqueue time (recorded in the Network Worker) from the current decoding time (recorded in the Decoder Worker), the result was a tiny negative number (e.g., `-5 ms`). 

Since the variables holding these times are unsigned integers (`uint32_t`), the negative number wrapped around backwards into a massive positive number (~`4.29` billion). When this was averaged against the framerate, it resulted in the `70,000,000+ ms` values displayed on the screen.

## How does this fix it?
This PR safely casts the time differences to signed integers (`int32_t`) before they are added to the totals. It then uses the `MAX(0, ...)` function to ensure that if the clock desynchronization produces a negative delay, we simply clamp it to `0` instead of allowing the variables to underflow into the billions.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.