### PR TITLE
fix: UI navigation double toggling and synchronous click issues on TV remotes

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -3277,7 +3277,7 @@ function saveVideoCodec() {
     updateVideoCodec('#h264', selectedH264Codec);
     snackbarLog(t('HDR has been disabled due to unsupported H.264 codec.'));
     // Turn off the HDR mode switch and save the state
-    $('#hdrModeSwitch').parent().removeClass('is-checked');
+    document.querySelector('#hdrModeBtn').MaterialSwitch.off();
     updateHdrMode();
   } else { // Selecting other video codecs while HDR mode is disabled
     // Continue to select the SDR profile of other video codecs
@@ -3325,7 +3325,7 @@ function saveHdrMode() {
       // H.264 does not support HDR profile, so stay on H.264 codec
       snackbarLog(t('H.264 codec does not support the HDR profile.'));
       // Turn off the HDR mode switch and save the state
-      $('#hdrModeSwitch').parent().removeClass('is-checked');
+      document.querySelector('#hdrModeBtn').MaterialSwitch.off();
       updateHdrMode();
     } else if (selectedVideoCodec === chosenHevcCodec) { // HEVC
       // Select the HDR profile of the HEVC codec (HEVC Main10)
@@ -3339,7 +3339,7 @@ function saveHdrMode() {
       // Unknown codec format does not support HDR profile
       snackbarLog(t('Selected codec does not support the HDR profile.'));
       // Turn off the HDR mode switch and save the state
-      $('#hdrModeSwitch').parent().removeClass('is-checked');
+      document.querySelector('#hdrModeBtn').MaterialSwitch.off();
       updateHdrMode();
     }
   }, 100);

--- a/wasm/platform/navigation.js
+++ b/wasm/platform/navigation.js
@@ -78,19 +78,17 @@ function clickElement(target) {
   }
   // Search for common toggle switch child elements within the target element
   const toggleSwitch = element.querySelector('input[type="checkbox"], .mdl-switch__input, [role="switch"], [aria-pressed]');
-  // If a clickable child element is found, use it instead of the container
+  // If a clickable child element is found, use it to trigger animations
   if (toggleSwitch && typeof toggleSwitch.click === 'function') {
-    // Dispatching events
+    // Dispatching events for MDL ripple animations
     const eventOptions = { view: window, bubbles: true, cancelable: true };
     toggleSwitch.dispatchEvent(new MouseEvent('mousedown', eventOptions));
     toggleSwitch.dispatchEvent(new MouseEvent('mouseup', eventOptions));
-    toggleSwitch.dispatchEvent(new MouseEvent('click', eventOptions));
     setTimeout(() => focusElement(toggleSwitch), 250);
-    return;
   }
   // Click the resolved element itself if it supports click event
   if (typeof element.click === 'function') {
-    isGamepadActive ? element.click() : target.click();
+    element.click();
   }
 }
 

--- a/wasm/platform/remote_controller.js
+++ b/wasm/platform/remote_controller.js
@@ -21,6 +21,7 @@ function remoteControllerHandler(e) {
       break;
     case tvKey.KEY_ENTER:
     case tvKey.KEY_REMOTE_ENTER:
+      e.preventDefault(); // Prevent native asynchronous click
       // Select the current item
       Navigation.accept();
       break;


### PR DESCRIPTION
# Fix UI double toggling, console errors, and MDL state desync

### Description
This PR resolves a critical issue where toggling settings switches (such as HDR Mode) using a TV remote's Enter key would immediately toggle back to the off state. It also eliminates the `Uncaught TypeError: target.click is not a function` console errors occurring during navigation, and corrects an issue where the MDL toggle switch UI would visually desync from its internal checked state when modified programmatically.

### Root Cause
1. **Double Toggling:** In previous versions, the `navigation.js` script attempted to programmatically dispatch a synthetic `click` event directly onto the inner `<input>` of MDL toggle switches to support gamepads. On TV remotes, this synthetic click would bubble up to the parent `<label>`, which the browser would interpret by natively firing a *second* click back down to the `<input>`, resulting in a double-toggle loop.
2. **Console Errors:** `navigation.js` was erroneously attempting to call `.click()` on the raw string IDs (e.g., `target.click()`) instead of the resolved physical DOM elements.
3. **MDL State Desync:** In `index.js`, certain validations (like unchecking the HDR switch) were done by manually removing the `is-checked` CSS class from the parent element. This only changed the visuals but left the inner `<input>` checked, causing the switch to require two clicks to turn on again.

### Fixes Implemented
- **Prevented Native Clicks:** Added `e.preventDefault()` for `KEY_ENTER` and `KEY_REMOTE_ENTER` in `remote_controller.js`. This safely cancels the TV browser's overlapping native click, ensuring we have full, predictable control over click dispatching.
- **Resolved Console Errors:** Simplified `clickElement()` in `navigation.js` to unconditionally execute `element.click()` on the resolved physical DOM element, rather than raw string IDs. 
- **Eliminated Bubbling Loop:** Removed the manual `click` dispatcher on the inner `<input type="checkbox">`. Programmatic clicks are now safely executed directly on the parent `<label>`, which natively and securely toggles the checkbox exactly once without triggering recursive event bubbling.
- **MDL API usage:** Updated `index.js` to correctly call `MaterialSwitch.off()` instead of manually manipulating the `is-checked` CSS class, ensuring the visual state and the DOM state remain synchronized.

### Fixes
Fix #135

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
