### PR TITLE
fix: Network timeouts by deferring Smart Hub Preview canvas generation

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -2282,8 +2282,8 @@ function showApps(host) {
 
         var boxArtPromises = [];
         
-        // Reset preview promises for this showApps invocation
-        window.previewPromises = [];
+        // Reset preview tasks for this showApps invocation
+        window.previewTasks = [];
 
         sortedAppList.forEach(function(app) {
           // Double clicking the button will cause multiple box arts to appear.
@@ -2425,15 +2425,28 @@ function showApps(host) {
         resolve();
 
         Promise.all(settledPromises).then(function() {
-          // Resume background polling now that all box art downloads are complete
-          beginBackgroundPollingOfHost(host);
+          // Sequentially generate all Smart Hub Preview JPEGs in the background
+          // after all network downloads are complete, preventing CPU starvation.
+          var tasks = window.previewTasks || [];
+          var sequentialPreviews = Promise.resolve();
+          
+          tasks.forEach(function(task) {
+            sequentialPreviews = sequentialPreviews.then(function() {
+              return task().then(function() {
+                // Yield to the Tizen OS event loop for 10ms between canvases
+                return new Promise(function(resolveStep) { setTimeout(resolveStep, 10); });
+              });
+            });
+          });
 
-          // Wait for all Smart Hub Preview JPEGs to finish encoding and saving to disk
-          // before sending the updated data to the background service.
-          var previewsDone = window.previewPromises || [];
-          Promise.all(previewsDone).then(function() {
+          sequentialPreviews.then(function() {
+            // Wait for all Smart Hub Preview JPEGs to finish encoding and saving to disk
+            // before sending the updated data to the background service.
             savePreviewApps();
             updatePreviewData();
+
+            // Resume background polling now that all box art downloads and preview processing are complete
+            beginBackgroundPollingOfHost(host);
           });
         });
       }, function(failedAppList) {

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -552,6 +552,21 @@ NvHTTP.prototype = {
 
       var self = this;
       
+      var queuePreviewTask = function(imgDataUrl, sourceInfo) {
+        if (!window.previewTasks) {
+          window.previewTasks = [];
+        }
+        window.previewTasks.push(function() {
+          return self.generatePreviewImage(imgDataUrl, appId).then(function(previewDataUrl) {
+            if (previewDataUrl) {
+              self.savePreviewImage(appId, previewDataUrl);
+            }
+          }).catch(function(error) {
+            console.warn('%c[utils.js, getBoxArt]', 'color: gray;', 'Warning: Failed to generate Smart Hub Preview box art from ' + sourceInfo + ' for app ID ' + appId + ': ' + error);
+          });
+        });
+      };
+      
       // Try to load the cached original box art from private storage
       try {
         // Open the cached original PNG box art for reading
@@ -601,20 +616,11 @@ NvHTTP.prototype = {
         }
 
         // Generate and save the optimized JPEG preview box art asynchronously from storage.
+        // We push this to a task queue so it can be executed sequentially in the background
+        // AFTER all network requests have completed, preventing CPU starvation.
+        queuePreviewTask(dataUrl, 'storage');
+
         // The original PNG box art can be returned immediately without waiting for preview generation.
-        var previewPromise = self.generatePreviewImage(dataUrl, appId).then(function(previewDataUrl) {
-          if (previewDataUrl) {
-            self.savePreviewImage(appId, previewDataUrl);
-          }
-        }, function(error) {
-          console.warn('%c[utils.js, getBoxArt]', 'color: gray;', 'Warning: Failed to generate Smart Hub Preview box art from storage for app ID ' + appId + ': ' + error);
-        });
-
-        if (!window.previewPromises) {
-          window.previewPromises = [];
-        }
-        window.previewPromises.push(previewPromise);
-
         resolve(dataUrl);
       } catch (readError) {
         // The original PNG box art is not available locally, so fetch it from the host
@@ -667,20 +673,11 @@ NvHTTP.prototype = {
             }
 
             // Generate and save the optimized JPEG preview box art asynchronously from network.
+            // We push this to a task queue so it can be executed sequentially in the background
+            // AFTER all network requests have completed, preventing CPU starvation.
+            queuePreviewTask(dataUrl, 'network');
+
             // The original PNG box art can be returned immediately without waiting for preview generation.
-            var previewPromise = self.generatePreviewImage(dataUrl, appId).then(function(previewDataUrl) {
-              if (previewDataUrl) {
-                self.savePreviewImage(appId, previewDataUrl);
-              }
-            }, function(error) {
-              console.warn('%c[utils.js, getBoxArt]', 'color: gray;', 'Warning: Failed to generate Smart Hub Preview box art from network for app ID ' + appId + ': ' + error);
-            });
-
-            if (!window.previewPromises) {
-              window.previewPromises = [];
-            }
-            window.previewPromises.push(previewPromise);
-
             resolve(dataUrl);
           };
 


### PR DESCRIPTION
## Description
This PR fixes the `Timeout was reached` (curl error 28) and `Failed to retrieve original box art from network: -1` errors introduced in v1.15.0 when loading the app list from a host.

### Root Cause
In v1.15.0, the Smart Hub Preview generation (`generatePreviewImage`) was added directly inside `getBoxArt`. When the user connects to a host with many apps (e.g., 40 apps), `index.js` fires all 40 `getBoxArt` promises concurrently. The cached images load instantly and immediately trigger 40 heavy HTML5 `<canvas>` encoding tasks (`canvas.toDataURL("image/jpeg")`) in parallel. 

Because the JavaScript engine on older Tizen TVs is single-threaded and runs on a weak CPU, this parallel processing completely froze the JS thread and starved the OS scheduler. As a result, the C++ `curl` requests running in the background Dispatcher thread could not complete their TLS handshakes within the hardcoded 3-second `CURLOPT_CONNECTTIMEOUT`, dropping the connections.

### Solution
This PR solves the timeout issue by completely decoupling the canvas processing from the loading phase:
1. **Deferred Processing**: `getBoxArt` now pushes the canvas processing function into a new `window.previewTasks` array and returns the image immediately.
2. **Instant UI & Network**: The UI renders the full-resolution PNG box arts instantly, and the C++ network Dispatcher has 100% of the TV's CPU to finish all `curl` requests without ever hitting a timeout.
3. **Sequential Background Queue**: Once all 40 box arts are fully downloaded and displayed (`Promise.all(settledPromises)`), `index.js` iterates through `window.previewTasks` and executes the canvas processing sequentially in the background with a 10ms breather between each image. 

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

**Test Steps:**

As shown in the logs below, the TV now successfully fetches all box arts via `curl` first, and only *afterward* does the background queue process the previews sequentially:

```js
moonlight-wasm.js:1 CURL: https://192.168.1.73:47984/appasset... -> No error
utils.js:640 [utils.js, getBoxArt] Returning network-fetched box art:  495309051
moonlight-wasm.js:1 CURL: https://192.168.1.73:47984/appasset... -> No error
utils.js:640 [utils.js, getBoxArt] Returning network-fetched box art:  1653636579
... (all curl requests finish successfully) ...

utils.js:806 [utils.js, generatePreviewImage] Created preview image for app ID 1092288683: 15 KB (600x800, quality 0.85)
utils.js:876 [utils.js, savePreviewImage] Saved preview image: documents/preview-1092288683.jpg (15 KB)
utils.js:806 [utils.js, generatePreviewImage] Created preview image for app ID 458551746: 15 KB (600x800, quality 0.85)
utils.js:876 [utils.js, savePreviewImage] Saved preview image: documents/preview-458551746.jpg (15 KB)
... (sequential background processing) ...

index.js:2990 [index.js, savePreviewApps] Saving preview apps data...
index.js:4332 [index.js, updatePreviewData] Launching Smart Hub service with preview data...
index.js:4364 [index.js, updatePreviewData] Preview data sent to service: MoonLight2.service
```

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
