### PR TITLE
chore: Backport static HTML update dialog structural changes

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -771,6 +771,17 @@
       </div>
     </dialog>
   </div>
+  <div id="updateAppDialogOverlay" class="dialog-overlay">
+    <dialog id="updateAppDialog" class="mdl-dialog">
+      <h3 id="updateAppDialogTitle" class="mdl-dialog__title" data-i18n="Update Moonlight">Update Moonlight</h3>
+      <div class="mdl-dialog__content">
+        <p id="updateAppDialogText" class="update-app-text"></p>
+      </div>
+      <div class="mdl-dialog__actions">
+        <button type="button" id="closeUpdateApp" autofocus class="mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect" data-i18n="Close">Close</button>
+      </div>
+    </dialog>
+  </div>
   <div id="snackbar" class="mdl-snackbar mdl-js-snackbar">
     <div class="mdl-snackbar__text"></div>
     <button type="button" id="snackButton" class="mdl-snackbar__action"></button>

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -1782,8 +1782,8 @@ function updateAppButton(latestVersion) {
 // Show the Update Moonlight dialog
 function updateAppDialog(latestVersion, releaseNotes) {
   // Find the existing overlay and dialog elements
-  var updateAppDialogOverlay = document.querySelector('#updateAppDialogOverlay');
-  var updateAppDialog = document.querySelector('#updateAppDialog');
+  var updateAppDialogOverlay = $('#updateAppDialogOverlay');
+  var updateAppDialog = $('#updateAppDialog');
 
   // Reset the dialog title
   $('#updateAppDialogTitle').text(t('Update Moonlight'));
@@ -1799,21 +1799,21 @@ function updateAppDialog(latestVersion, releaseNotes) {
   closeUpdateAppDialog.text(t('Close'));
   closeUpdateAppDialog.off('click').click(function() {
     console.log('%c[index.js, updateAppDialog]', 'color: green;', 'Closing app dialog and returning.');
-    updateAppDialogOverlay.style.display = 'none';
-    updateAppDialog.close();
+    updateAppDialogOverlay.css('display', 'none');
+    updateAppDialog[0].close();
     isDialogOpen = false;
     Navigation.pop();
     Navigation.switch();
   });
 
   // If the dialog element doesn't support the showModal method, register it with dialogPolyfill
-  if (!updateAppDialog.showModal) {
-    dialogPolyfill.registerDialog(updateAppDialog);
+  if (!updateAppDialog[0].showModal) {
+    dialogPolyfill.registerDialog(updateAppDialog[0]);
   }
 
   // Show the dialog and push the view
-  updateAppDialogOverlay.style.display = 'flex';
-  updateAppDialog.showModal();
+  updateAppDialogOverlay.css('display', 'flex');
+  updateAppDialog[0].showModal();
   isDialogOpen = true;
   Navigation.push(Views.UpdateMoonlightDialog);
   setTimeout(() => Navigation.switch(), 5);

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -1781,73 +1781,39 @@ function updateAppButton(latestVersion) {
 
 // Show the Update Moonlight dialog
 function updateAppDialog(latestVersion, releaseNotes) {
-  // Create an overlay for the dialog and append it to the body
-  var updateAppDialogOverlay = $('<div>', {
-    id: 'updateAppDialogOverlay',
-    class: 'dialog-overlay'
-  }).appendTo(document.body);
+  // Find the existing overlay and dialog elements
+  var updateAppDialogOverlay = document.querySelector('#updateAppDialogOverlay');
+  var updateAppDialog = document.querySelector('#updateAppDialog');
 
-  // Create the dialog element and append it to the overlay
-  var updateAppDialog = $('<dialog>', {
-    id: 'updateAppDialog',
-    class: 'mdl-dialog'
-  }).appendTo(updateAppDialogOverlay);
+  // Reset the dialog title
+  $('#updateAppDialogTitle').text(t('Update Moonlight'));
 
-  // Add a dialog title named Update Moonlight
-  $('<h3>', {
-    id: 'updateAppDialogTitle',
-    class: 'mdl-dialog__title',
-    'data-i18n': 'Update Moonlight',
-    text: t('Update Moonlight')
-  }).appendTo(updateAppDialog);
+  // Update the text dynamically
+  $('#updateAppDialogText').html(
+    t('Version %1$s is now available! Update manually to enjoy new features and improvements.', latestVersion) + '<br><br>' +
+    '<strong>' + t('What\'s Changed:') + '</strong><br>' + releaseNotes
+  );
 
-  // Create a content section inside the dialog
-  var updateAppDialogContent = $('<div>', {
-    class: 'mdl-dialog__content'
-  }).appendTo(updateAppDialog);
-
-  // Add a paragraph with multiple lines of text
-  $('<p>', {
-    id: 'updateAppDialogText',
-    class: 'update-app-text',
-    html: t('Version %1$s is now available! Update manually to enjoy new features and improvements.<br><br>', latestVersion) + 
-          t('<strong>What\'s Changed:</strong><br>%1$s', releaseNotes)
-  }).appendTo(updateAppDialogContent);
-
-  // Create the actions section inside the dialog
-  var updateAppDialogActions = $('<div>', {
-    class: 'mdl-dialog__actions'
-  }).appendTo(updateAppDialog);
-
-  // Create and set up the Close button
-  var closeUpdateAppDialog = $('<button>', {
-    type: 'button',
-    id: 'closeUpdateApp',
-    class: 'mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect',
-    'data-i18n': 'Close',
-    text: t('Close')
-  });
-
-  // Close the dialog if the Close button is pressed
-  closeUpdateAppDialog.off('click');
-  closeUpdateAppDialog.click(function() {
+  // Set up the Close button
+  var closeUpdateAppDialog = $('#closeUpdateApp');
+  closeUpdateAppDialog.text(t('Close'));
+  closeUpdateAppDialog.off('click').click(function() {
     console.log('%c[index.js, updateAppDialog]', 'color: green;', 'Closing app dialog and returning.');
-    $(updateAppDialogOverlay).css('display', 'none');
-    updateAppDialog[0].close();
-    updateAppDialogOverlay.remove();
+    updateAppDialogOverlay.style.display = 'none';
+    updateAppDialog.close();
     isDialogOpen = false;
     Navigation.pop();
     Navigation.switch();
-  }).appendTo(updateAppDialogActions);
+  });
 
   // If the dialog element doesn't support the showModal method, register it with dialogPolyfill
-  if (!updateAppDialog[0].showModal) {
-    dialogPolyfill.registerDialog(updateAppDialog[0]);
+  if (!updateAppDialog.showModal) {
+    dialogPolyfill.registerDialog(updateAppDialog);
   }
 
   // Show the dialog and push the view
-  $(updateAppDialogOverlay).css('display', 'flex');
-  updateAppDialog[0].showModal();
+  updateAppDialogOverlay.style.display = 'flex';
+  updateAppDialog.showModal();
   isDialogOpen = true;
   Navigation.push(Views.UpdateMoonlightDialog);
   setTimeout(() => Navigation.switch(), 5);

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -1781,64 +1781,30 @@ function updateAppButton(latestVersion) {
 
 // Show the Update Moonlight dialog
 function updateAppDialog(latestVersion, releaseNotes) {
-  // Create an overlay for the dialog and append it to the body
-  var updateAppDialogOverlay = $('<div>', {
-    id: 'updateAppDialogOverlay',
-    class: 'dialog-overlay'
-  }).appendTo(document.body);
+  // Find the existing overlay and dialog elements
+  var updateAppDialogOverlay = $('#updateAppDialogOverlay');
+  var updateAppDialog = $('#updateAppDialog');
 
-  // Create the dialog element and append it to the overlay
-  var updateAppDialog = $('<dialog>', {
-    id: 'updateAppDialog',
-    class: 'mdl-dialog'
-  }).appendTo(updateAppDialogOverlay);
+  // Reset the dialog title
+  $('#updateAppDialogTitle').text(t('Update Moonlight'));
 
-  // Add a dialog title named Update Moonlight
-  $('<h3>', {
-    id: 'updateAppDialogTitle',
-    class: 'mdl-dialog__title',
-    'data-i18n': 'Update Moonlight',
-    text: t('Update Moonlight')
-  }).appendTo(updateAppDialog);
+  // Update the text dynamically
+  $('#updateAppDialogText').html(
+    t('Version %1$s is now available! Update manually to enjoy new features and improvements.', latestVersion) + '<br><br>' +
+    '<strong>' + t('What\'s Changed:') + '</strong><br>' + releaseNotes
+  );
 
-  // Create a content section inside the dialog
-  var updateAppDialogContent = $('<div>', {
-    class: 'mdl-dialog__content'
-  }).appendTo(updateAppDialog);
-
-  // Add a paragraph with multiple lines of text
-  $('<p>', {
-    id: 'updateAppDialogText',
-    class: 'update-app-text',
-    html: t('Version %1$s is now available! Update manually to enjoy new features and improvements.<br><br>', latestVersion) + 
-          t('<strong>What\'s Changed:</strong><br>%1$s', releaseNotes)
-  }).appendTo(updateAppDialogContent);
-
-  // Create the actions section inside the dialog
-  var updateAppDialogActions = $('<div>', {
-    class: 'mdl-dialog__actions'
-  }).appendTo(updateAppDialog);
-
-  // Create and set up the Close button
-  var closeUpdateAppDialog = $('<button>', {
-    type: 'button',
-    id: 'closeUpdateApp',
-    class: 'mdl-button mdl-js-button mdl-button--raised mdl-button--colored mdl-js-ripple-effect',
-    'data-i18n': 'Close',
-    text: t('Close')
-  });
-
-  // Close the dialog if the Close button is pressed
-  closeUpdateAppDialog.off('click');
-  closeUpdateAppDialog.click(function() {
+  // Set up the Close button
+  var closeUpdateAppDialog = $('#closeUpdateApp');
+  closeUpdateAppDialog.text(t('Close'));
+  closeUpdateAppDialog.off('click').click(function() {
     console.log('%c[index.js, updateAppDialog]', 'color: green;', 'Closing app dialog and returning.');
-    $(updateAppDialogOverlay).css('display', 'none');
+    updateAppDialogOverlay.css('display', 'none');
     updateAppDialog[0].close();
-    updateAppDialogOverlay.remove();
     isDialogOpen = false;
     Navigation.pop();
     Navigation.switch();
-  }).appendTo(updateAppDialogActions);
+  });
 
   // If the dialog element doesn't support the showModal method, register it with dialogPolyfill
   if (!updateAppDialog[0].showModal) {
@@ -1846,7 +1812,7 @@ function updateAppDialog(latestVersion, releaseNotes) {
   }
 
   // Show the dialog and push the view
-  $(updateAppDialogOverlay).css('display', 'flex');
+  updateAppDialogOverlay.css('display', 'flex');
   updateAppDialog[0].showModal();
   isDialogOpen = true;
   Navigation.push(Views.UpdateMoonlightDialog);


### PR DESCRIPTION
### Description
This PR refactors the "Update Moonlight" dialog to use static HTML rather than dynamically generating the DOM elements via jQuery in JavaScript. 

Previously, `updateAppDialogOverlay` and all its child elements (titles, text, buttons) were built on-the-fly and appended to the body every time an update was found. By moving the structural HTML into `index.html`, we significantly improve code readability, maintain a cleaner separation of concerns between the UI structure and JavaScript logic, and reduce unnecessary DOM manipulation overhead.

### Changes Made
* Moved the `updateAppDialogOverlay` and its modal structure into `wasm/index.html`.
* Refactored `updateAppDialog()` in `wasm/platform/index.js` to query the existing static DOM elements instead of generating them.
* Maintained the original informational behavior (notifying users to update manually) while preserving the new, cleaner architecture.

---

## Type of Change

Please select the relevant option(s):
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [X] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

**Test Steps:**
1. Verified the update dialog still correctly renders and triggers when a new version is detected.
2. Verified the dialog safely closes and restores spatial navigation focus.

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
