### PR TITLE
fix: Restore update button after app restart using cached version

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -58,6 +58,7 @@ const REPEAT_INTERVAL = 100; // Repeat interval set to 100ms (milliseconds)
 const ACTION_THRESHOLD = 0.5; // Threshold for initial navigation set to 0.5
 const NAVIGATION_DELAY = 150; // Navigation delay set to 150ms (milliseconds)
 const UPDATE_TIMESTAMP = 'lastUpdateCheck'; // Use the update check timestamp key to determine the last update check
+const UPDATE_VERSION = 'latestUpdateVersion'; // Key to cache the latest found version
 const UPDATE_INTERVAL = 24 * 60 * 60 * 1000; // Automatic check for updates interval is set to 24 hours
 
 // Called by the common.js module
@@ -1900,6 +1901,8 @@ function checkForAppUpdatesAtStartup() {
             updateAppButton(latestVersion);
           }
         }, 100);
+        // Save the fetched version
+        storeData(UPDATE_VERSION, latestVersion);
       }).catch(error => {
         console.error('%c[index.js, checkForAppUpdatesAtStartup]', 'color: green;', 'Error: Failed to fetch the release data!', error);
         snackbarLogLong(t('Cannot automatically check for updates at this time!'));
@@ -1917,6 +1920,17 @@ function checkForAppUpdatesAtStartup() {
         'Auto-update check skipped as the last one was within the past 24 hours. ' + 
         `Next auto-check will occur in ${hoursLeft} hour${hoursLeft !== 1 ? 's' : ''} and ${minutesLeft} minute${minutesLeft !== 1 ? 's' : ''}.`
       );
+
+      // Still show the update button if a newer version was previously cached
+      getData(UPDATE_VERSION, function(vResult) {
+        var cachedVersion = vResult[UPDATE_VERSION];
+        if (cachedVersion !== undefined && checkVersionUpdate(appInfo.version, cachedVersion)) {
+          setTimeout(() => {
+            snackbarLogLong(t('Version %1$s is now available! Check out the latest features & improvements.', cachedVersion));
+            updateAppButton(cachedVersion);
+          }, 100);
+        }
+      });
     }
   });
 }


### PR DESCRIPTION
## Description

This PR backports a fix to ensure that users do not lose their "Update Available" notification and toolbar button if they restart the app or their TV within the 24-hour update check cooldown period.

### Changes Made
* Added an `UPDATE_VERSION` constant (`latestUpdateVersion`) to interface with `IndexedDB`.
* When `checkForAppUpdatesAtStartup()` successfully fetches a new version from GitHub, it now caches that version locally.
* If the app is launched again within 24 hours, the GitHub API fetch is skipped (to prevent rate limiting), but the script now safely reads the cached `UPDATE_VERSION`. If the cached version is newer than the currently installed app, it will re-trigger the snackbar and `updateAppButton()` so the user is still prompted to update.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
