### PR TITLE
fix: Display update button after manual update check

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -1864,6 +1864,8 @@ function checkForAppUpdates() {
       if (checkVersionUpdate(appInfo.version, latestVersion)) {
         // Show the Update Moonlight dialog with new version and release notes to inform user to update the app
         updateAppDialog(latestVersion, releaseNotes);
+        // Create and display the Update App button at the top of the app so they can access it later if they close the dialog
+        updateAppButton(latestVersion);
       } else {
         // Otherwise, show a snackbar message to inform the user that the app is already up to date
         snackbarLogLong(t('Your app is already up to date! You\'re on the latest version.'));

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -1712,6 +1712,9 @@ function formatUpdateTimestamp(ms) {
 
 // Show the Update App button when a new update is found
 function updateAppButton(latestVersion) {
+  // Prevent adding duplicate buttons if one already exists
+  if ($('#updateAppBtn').length > 0) return;
+
   // Create the button dynamically
   var updateAppBtn = $('<button>', {
     type: 'button',
@@ -1864,6 +1867,8 @@ function checkForAppUpdates() {
       if (checkVersionUpdate(appInfo.version, latestVersion)) {
         // Show the Update Moonlight dialog with new version and release notes to inform user to update the app
         updateAppDialog(latestVersion, releaseNotes);
+        // Create and display the Update App button at the top of the app so they can access it later if they close the dialog
+        updateAppButton(latestVersion);
       } else {
         // Otherwise, show a snackbar message to inform the user that the app is already up to date
         snackbarLogLong(t('Your app is already up to date! You\'re on the latest version.'));


### PR DESCRIPTION
## Description

This PR backports a fix to ensure the persistent "Update Available" toolbar button is created when a user triggers an update check manually, while preventing duplicate buttons from spawning if the user checks multiple times.

### Changes Made
* Added `updateAppButton(latestVersion)` to the success handler of `checkForAppUpdates()` in `wasm/platform/index.js`.
* Previously, if a user navigated to Settings and clicked "Check for Updates," the Update Dialog would appear, but if they dismissed it, the persistent toolbar notification button would never appear. This change ensures the button is properly created so users can easily re-access the update information later without needing to return to the Settings panel.
* Backported the `if ($('#updateAppBtn').length > 0) return;` safeguard inside `updateAppButton()` to prevent duplicate update buttons from stacking in the UI if the user manually checks for updates multiple times in a single session.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
