### PR TITLE
feat: Add Hamburger Menu Highlight Step When Pressing Up on Host Card

### DIFF
--- a/wasm/platform/navigation.js
+++ b/wasm/platform/navigation.js
@@ -429,10 +429,17 @@ const Views = {
       if (this.view.prevCardRow(5)) {
         focusElement(this.view.current());
       } else {
-        // If there are no more rows, navigate to the HostsNav view
-        Navigation.change(Views.HostsNav);
-        // Set focus on the first navigation item in HostsNav view when transitioning from Hosts view
-        focusElement(Views.HostsNav.view.current());
+        // If there are no more rows, check if the current item is a host
+        const currentItem = resolveElement(this.view.current());
+        if (currentItem && currentItem.id !== 'addHostContainer') {
+          // Navigate to the HostsMenuHighlight view to highlight the host's menu icon
+          Navigation.change(Views.HostsMenuHighlight);
+          focusElement(Views.HostsMenuHighlight.view.current());
+        } else {
+          // Set focus on the first navigation item in HostsNav view when transitioning from Add Host container
+          Navigation.change(Views.HostsNav);
+          focusElement(Views.HostsNav.view.current());
+        }
       }
     },
     down: function() {
@@ -529,6 +536,54 @@ const Views = {
       // Navigate to the Hosts view
       Navigation.change(Views.Hosts);
       // Set focus on the first navigation item in Hosts view when transitioning from HostsNav view
+      focusElement(Views.Hosts.view.current());
+    },
+    press: function() {},
+    switch: function() {
+      focusElement(this.view.current());
+    },
+    enter: function() {
+      mark(this.view.current());
+    },
+    leave: function() {
+      unmark(this.view.current());
+    },
+  },
+  HostsMenuHighlight: {
+    view: new ListView(() => {
+      // Return the menu button of the currently selected host
+      const currentHost = resolveElement(Views.Hosts.view.current());
+      if (currentHost && currentHost.id !== 'addHostContainer') {
+        const menuButton = currentHost.children ? currentHost.children[1] : null;
+        return menuButton ? [menuButton] : [];
+      }
+      return [];
+    }),
+    up: function() {
+      // Navigate to the HostsNav view (Settings button)
+      Navigation.change(Views.HostsNav);
+      focusElement(Views.HostsNav.view.current());
+    },
+    down: function() {
+      // Return to the Hosts view
+      Navigation.change(Views.Hosts);
+      focusElement(Views.Hosts.view.current());
+    },
+    left: function() {},
+    right: function() {},
+    accept: function() {
+      // Open the host menu dialog (same behavior as CH+)
+      const currentHost = resolveElement(Views.Hosts.view.current());
+      if (currentHost && currentHost.id !== 'addHostContainer') {
+        const menuButton = currentHost.children ? currentHost.children[1] : null;
+        if (menuButton) {
+          clickElement(menuButton);
+        }
+      }
+    },
+    back: function() {
+      // Return to the Hosts view
+      Navigation.change(Views.Hosts);
       focusElement(Views.Hosts.view.current());
     },
     press: function() {},


### PR DESCRIPTION
## Description

Currently, when a host card is selected in the host grid and the user presses Up on the remote, navigation jumps directly to the Settings button in the header navigation bar (`HostsNav` view). This PR adds an intermediate step: pressing Up should first highlight the host's hamburger menu icon (☰) without opening it, similar to how CH+ selects it but without the auto-click.

- **Before**: Host Card → Settings Button (HostsNav)
- **After**: Host Card → Hamburger Menu Icon (highlighted) → Settings Button (HostsNav)

<img width="4032" height="3024" alt="IMG_1218" src="https://github.com/user-attachments/assets/3f4f4473-bde9-4203-b5fb-591856aae91a" />

From highlighted hamburger menu:
- Enter → Opens host context menu dialog
- Up → Navigates to Settings button (HostsNav)  
- Down → Returns to host card

---

## Type of Change

Please select the relevant option(s):
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

**Test Steps:**
- [X] Select a host card and press Up → hamburger menu icon should highlight (glow blue) without opening menu
- [X] Press Enter → host menu dialog should open
- [X] Press Back to close dialog, select host again
- [X] Press Up → hamburger icon highlights
- [X] Press Up again → navigates to Settings button in header
- [X] Press Down → navigates back to host card
- [X] Select Add Host card and press Up → should go directly to Settings (no hamburger menu for Add Host)
- [X] Verify CH+ still works as before (opens menu directly)

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
