### PR TITLE
fix: Redundant database write for i18n language preference on startup

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -3720,8 +3720,8 @@ function loadUserDataCb() {
     // Update the language field based on the stored value
     $('#selectLanguage').attr('data-value', savedLanguagePreference).data('value', savedLanguagePreference);
     // Apply the stored language preference if the i18n object is available
-    if (window.i18n && typeof window.i18n.applyLanguagePreference === 'function') {
-      window.i18n.applyLanguagePreference(savedLanguagePreference).catch((error) => {
+    if (window.i18n && typeof window.i18n.setLanguage === 'function') {
+      window.i18n.setLanguage(savedLanguagePreference).catch((error) => {
         console.error('%c[index.js, loadUserDataCb]', 'color: green;', 'Error: Failed to apply stored language: ' + error);
       });
     }


### PR DESCRIPTION
## Description
When the application starts, it reads stored user preferences to initialize the UI and internal state. For the language preference, `loadUserDataCb` was mistakenly calling `window.i18n.applyLanguagePreference()`. Because this function is designed for when a user explicitly chooses a new language in the settings menu, it not only updates the locale but also immediately triggers a write operation back to the settings database.

This caused a redundant IndexedDB write operation every time the app launched (since it was just writing the same value it had loaded milliseconds prior).

This pull request resolves the issue by switching the startup initialization to use `window.i18n.setLanguage()`, which updates the UI and internal locale without needlessly storing the value again.

## Changes
- In `wasm/platform/index.js`, replaced `window.i18n.applyLanguagePreference()` with `window.i18n.setLanguage()` during initial preference loading to prevent unnecessary `storeData` calls on application startup.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

**Test Steps:**

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
