### PR TITLE
fix: Added UI click debouncer to prevent concurrent hostChosen executions

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -28,6 +28,7 @@ try {
 }
 var isHdrCapable = webapis.avinfo.isHdrTvSupport(); // Check if the device supports HDR
 var hosts = {}; // Hosts is an associative array of NvHTTP objects, keyed by server UID
+var isHostOpening = false; // Prevents concurrent hostChosen executions
 var activePolls = {}; // Hosts currently being polled. An associated array of polling IDs, keyed by server UID
 var pairingCert; // Loads the generated certificate
 var myUniqueid;
@@ -523,13 +524,18 @@ function restoreUiAfterWasmLoad() {
 }
 
 function hostChosen(host) {
+  if (isHostOpening) return;
+  isHostOpening = true;
+
   if (isPairingInProgress) {
+    isHostOpening = false;
     snackbarLogLong(t('A pairing request is currently in progress. Please wait for it to timeout or finish before trying again.'));
     return;
   }
 
   // If the host is already offline or fails to connect, notify the user.
   if (!host.online) {
+    isHostOpening = false;
     // Let the user know what to do to bring the host back online and until then, we'll be back to the previous view.
     console.error('%c[index.js, hostChosen]', 'color: green;', 'Error: Connection to host failed or host is offline!');
     snackbarLogLong(t('Failed to connect to %1$s. Ensure Sunshine is running on your host PC or GameStream is enabled in GeForce Experience SHIELD settings.', 'the host'));
@@ -552,9 +558,12 @@ function hostChosen(host) {
         Navigation.switch();
         // Switch to Apps view
         Navigation.change(Views.Apps);
-      }).catch(console.error);
+      }).catch(console.error).finally(() => {
+        isHostOpening = false;
+      });
     }, function() {
       // Start polling the host after pairing flow
+      isHostOpening = false;
       startPollingHosts();
     });
   } else {
@@ -565,7 +574,9 @@ function hostChosen(host) {
       Navigation.switch();
       // Switch to Apps view
       Navigation.change(Views.Apps);
-    }).catch(console.error);
+    }).catch(console.error).finally(() => {
+      isHostOpening = false;
+    });
   }
 }
 


### PR DESCRIPTION
## Description
This PR addresses an issue where rapid or multiple clicks on a host could trigger concurrent executions of the `hostChosen` logic. This could lead to overlapping network requests, race conditions in the UI state, and unexpected navigation behavior.

## Changes
- **Added `isHostOpening` flag (`wasm/platform/index.js`):** Introduced a state variable to debounce the `hostChosen` function.
- **Lifecycle Management:** The function now immediately returns if a host is already in the process of opening. The flag is safely reset to `false` in all early-return paths (e.g., if a pairing is already in progress, or the host is offline) and within `.finally()` blocks to ensure the lock is always released after the promise resolves or rejects.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
